### PR TITLE
Update octeval.cc to compile against Octave 5+

### DIFF
--- a/mbxmlutils/mbxmlutils/octeval.cc
+++ b/mbxmlutils/mbxmlutils/octeval.cc
@@ -500,7 +500,7 @@ Eval::Value OctEval::fullStringToValue(const string &str, const DOMElement *e) c
     REDIR_STDOUT(out.rdbuf());
     REDIR_STDERR(err.rdbuf());
     mbxmlutilsStaticDependencies.clear();
-    eval_string(str, true, dummy, 0); // eval as statement list
+    octInit.interpreter->eval_string(str, true, dummy, 0); // eval as statement list
     addStaticDependencies(e);
   }
   catch(const exception &ex) { // should not happend


### PR DESCRIPTION
Direct call to eval_string function is deprecated. Need to call interpreter object first. Otherwise there is ambiguity.